### PR TITLE
Dom node migration.

### DIFF
--- a/popout.html
+++ b/popout.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>PopOut!</title></head>
+  <style>
+  	overflow-y: hidden;
+	background: url("ui/parchment.jpg") repeat;
+  </style>
+  <body></body>
+</html>

--- a/popout.js
+++ b/popout.js
@@ -1,15 +1,18 @@
+"use strict";
+
 class PopoutModule {
     constructor() {
         this.poppedOut = new Map();
-        this.TIMEOUT_INTERVAL = 25 // ms
-        this.MAX_TIMEOUT = 250; // ms
+        this.TIMEOUT_INTERVAL = 50; // ms
+        this.MAX_TIMEOUT = 1000; // ms
         // Random id to prevent collision with other modules;
-        this.ID = [...Array(24)].map(() => Math.floor(Math.random() * 16).toString(16)).join("");
+        this.ID = randomID(24);
     }
 
     log(msg, ...args) {
         if (game && game.settings.get("popout", "verboseLogs")) {
-            const color = "background: #6699ff; color: #000; font-size: larger;";
+            const color =
+                "background: #6699ff; color: #000; font-size: larger;";
             console.debug(`%c PopoutModule: ${msg}`, color, ...args);
         }
     }
@@ -17,152 +20,162 @@ class PopoutModule {
     async init() {
         game.settings.register("popout", "useWindows", {
             name: "Pop sheets out into windows",
-            hint: "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
+            hint:
+                "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
             scope: "client",
             config: true,
             default: false,
-            type: Boolean
+            type: Boolean,
         });
 
         game.settings.register("popout", "verboseLogs", {
             name: "Enable more module logging.",
-            hint: "Enables more verbose module logging. This is useful for debugging the module. But otherwise should be left off.",
+            hint:
+                "Enables more verbose module logging. This is useful for debugging the module. But otherwise should be left off.",
             scope: "client",
-            config: true,
+            config: false,
             default: false,
-            type: Boolean
+            type: Boolean,
         });
-
 
         // We replace the games window registry with a proxy object so we can intercept
         // every new application window creation event.
         const handler = {
-            set: (obj, prop, value) => {
+            set: async (obj, prop, value) => {
                 const result = Reflect.set(obj, prop, value);
-                this.log("Intercept ui-window create", value)
+                this.log("Intercept ui-window create", value);
                 try {
                     if (value && value.options && value.options.popOut) {
-                        this.addPopout(value);
+                        await this.addPopout(value);
                     }
                 } catch (err) {
                     // We must never fail here.
                     this.log(err);
                 }
-                return result
-            }
+                return result;
+            },
         };
         ui.windows = new Proxy(ui.windows, handler);
         this.log("Installed window interceptor", ui.windows);
 
-        // HACK(aposney: 2020-07-12): we need to init tinymce to ensure it's plugins 
+        // NOTE(posnet: 2020-07-12): we need to initialize TinyMCE to ensure its plugins,
         // are loaded into the frame. Otherwise our popouts will not be able to access
-        // the lazy loaded javascript mce plugins. 
-        const elem = $("<div style=\"display: none;\"><p id=\"mce_init\"> foo </p></div>")
-        $("body").append(elem)
+        // the lazy loaded JavaScript mce plugins.
+        // This will affect any module that lazy loads JavaScript. And require special handling.
+        const elem = $(
+            `<div style="display: none;"><p id="mce_init"> foo </p></div>`
+        );
+        $("body").append(elem);
         const config = { target: elem[0], plugins: CONFIG.TinyMCE.plugins };
         const editor = await tinyMCE.init(config);
         editor[0].remove();
     }
 
-    addPopout(app) {
-        this._addPopout(app, 0);
-    }
-
-
-    _addPopout(app, recurse) {
-        if (recurse > this.MAX_TIMEOUT) {
-            this.log("Timeout out waiting for app to render");
-            return;
+    async addPopout(app) {
+        let waitRender = Math.floor(this.MAX_TIMEOUT / this.TIMEOUT_INTERVAL);
+        while (
+            app._state !== Application.RENDER_STATES.RENDERED &&
+            waitRender-- > 0
+        ) {
+            await new Promise((r) => setTimeout(r, this.TIMEOUT_INTERVAL));
         }
-
-        if (!(app._state == Application.RENDER_STATES.RENDERED)) {
-            window.setTimeout(() => {
-                this._addPopout(app, recurse + this.TIMEOUT_INTERVAL);
-            }, this.TIMEOUT_INTERVAL);
+        if (app._state !== Application.RENDER_STATES.RENDERED) {
+            this.log("Timeout out waiting for app to render");
             return;
         }
 
         if (this.poppedOut.has(app.appId)) {
             this.log("Already popped out");
-            this.poppedOut.get(app.appId).focus();
+            this.poppedOut.get(app.appId).window.focus();
             return;
         }
 
-
-        if (app && app.options && app.options.classes.includes("dialog")) {
-            this.log("is dialog");
-            if (app.actor && app.actor.apps) {
-                const keys = Object.keys(app.actor.apps);
-                this.log("has an apps keys", keys);
-                if (keys.length == 1) {
-                    const parent = app.actor.apps[keys[0]]
-                    if (this.poppedOut.has(parent.appId)) {
-                        this.log("Intercepting dialog of popped out window.");
-                        this.moveDialog(app, parent);
-                        return;
-                    }
-                }
-            }
+        if (this.handleChildDialog(app)) {
+            return;
         }
 
         const domID = `popout_${this.ID}_${app.appId}`;
-        if (!document.getElementById(domID)) { // Don't create a second link on re-renders;
-            const link = $(`<a id="${domID}"><i class="fas fa-external-link-alt"></i>Popout</a>`)
-            link.on("click", () => this.onPopoutClicked(app));
+        if (!document.getElementById(domID)) {
+            // Don't create a second link on re-renders;
+            const link = $(
+                `<a id="${domID}"><i class="fas fa-external-link-alt"></i>Popout</a>`
+            );
+            link.on("click", () => this.onPopoutClicked(domID, app));
             const title = app.element.find(".window-title").after(link);
             this.log("Attached", app);
         }
     }
 
-    moveDialog(app, parent) {
-        const parentWindow = this.poppedOut.get(parent.appId);
+    handleChildDialog(app) {
+        // This handler attempts to make behavior less confusing for modal/dialog like interactions
+        // with a popped out window. A concrete example being a `pick spell level dialog` in response to
+        // casting a spell.
+        // The intended behavior is that new dialogs, (that have a child relationship to a parent popped out window),
+        // get moved to the popped out window.
+        // There are 2 heuristics we use to identify if something is a dialog.
+
+        // The first is to check if the app has exactly one actor, then we assume that
+        // actor is this apps parent.
+        if (app && app.actor && app.actor.apps) {
+            const keys = Object.keys(app.actor.apps);
+            if (keys.length == 1) {
+                const parent = app.actor.apps[keys[0]];
+                if (this.poppedOut.has(parent.appId)) {
+                    this.log("Intercepting dialog of popped out window.");
+                    this.moveDialog(app, parent);
+                    return true;
+                }
+            }
+        }
+
+        // The second is to check if the app has exactly 1 app in its object list.
+        // and that app is *not* the surrounding app, in which case we assume
+        // that the app in the object list is the true application.
+        if (app && app.object && app.object.apps) {
+            const keys = Object.keys(app.object.apps);
+            if (keys.length == 1) {
+                const parent = app.object.apps[keys[0]];
+                if (this.poppedOut.has(parent.appId)) {
+                    this.log("Intercepting dialog of popped out window.");
+                    this.moveDialog(app, parent);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    moveDialog(app, parentApp) {
+        const parent = this.poppedOut.get(parentApp.appId);
         const dialogNode = app.element[0];
 
         // Hide element
         const setDisplay = dialogNode.style.display;
         dialogNode.style.display = "None";
 
-        const newHeader = parentWindow.document.createElement("header")
+        const newHeader = parent.window.document.createElement("header");
         newHeader.setAttribute("class", "window-header flexrow");
         const headerElements = dialogNode.children[0].children;
-        for (const element of Array.from(headerElements)) {
-            newHeader.appendChild(parentWindow.document.adoptNode(element));
+        for (const element of [...headerElements]) {
+            newHeader.appendChild(parent.window.document.adoptNode(element));
         }
 
-        dialogNode.children[0].remove()
+        dialogNode.children[0].remove();
 
-        const node = parentWindow.document.adoptNode(dialogNode);
+        const node = parent.window.document.adoptNode(dialogNode);
         node.style.top = "50%";
         node.style.left = "50%";
-        node.style.transform = "translate(-50%, -50%)"
+        node.style.transform = "translate(-50%, -50%)";
 
         node.insertBefore(newHeader, node.children[0]);
 
-        parent.element[0].parentNode.insertBefore(node, parent.element[0].nextSibling);
+        parent.node.parentNode.insertBefore(node, parent.node.nextSibling);
         node.style.display = setDisplay;
+        parent.children.push(app);
     }
 
-
-    onPopoutClicked(app) {
-        // Check if popout in Electron window
-        if (navigator.userAgent.toLowerCase().indexOf(" electron/") !== -1) {
-            ui.notifications.warn("Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.");
-            return;
-        }
-
-        // -------------------- Obtain application --------------------
-
-        // Store original position for later use.
-        const appPosition = { ...app.position };
-        const appMinimized = app._minimized;
-
-
-        // Hide the original node;
-        const appNode = app._element[0];
-        appNode.style.display = "none";
-
-        // -------------------- Create Document --------------------
-
+    createDocument() {
         // Create the new document.
         // Currently using raw js apis, since I need to ensure
         // jquery isn't doing something sneaky underneath.
@@ -172,58 +185,131 @@ class PopoutModule {
         // to the new window is race condition with the page load.
         // But since we are directing to a 404, it doesn't matter other than for UX purposes.
         const html = document.createElement("html");
-        const serializer = new XMLSerializer();
-        const doctype = serializer.serializeToString(document.doctype);
-        const head = document.importNode(document.getElementsByTagName("head")[0], true);
-        const body = document.importNode(document.getElementsByTagName("body")[0], false);
+        const head = document.importNode(
+            document.getElementsByTagName("head")[0],
+            true
+        );
+        const body = document.importNode(
+            document.getElementsByTagName("body")[0],
+            false
+        );
 
-        // Remove script tags from cloned head.
         for (const child of [...head.children]) {
-            if ((child.nodeName === "SCRIPT") &&
-                child.src &&
-                !child.src.match(/tinymce|jquery/)) {
-                child.remove();
+            if (child.nodeName === "SCRIPT" && child.src) {
+                const src = child.src.replace(window.location.origin, "");
+                if (!src.match(/tinymce|jquery|webfont|pdfjs/)) {
+                    child.remove();
+                }
             }
         }
 
         html.appendChild(head);
         html.appendChild(body);
+        return html;
+    }
 
-        // -------------------- Create window --------------------
-
+    windowFeatures(app) {
         let windowFeatures = undefined;
         if (game.settings.get("popout", "useWindows")) {
             const padding = 30;
-            const innerWidth = app._element.innerWidth() + padding * 2;
-            const innerHeight = app._element.innerHeight() + padding * 2;
-            const position = app._element.position;
+            const innerWidth = app.element.innerWidth() + padding * 2;
+            const innerHeight = app.element.innerHeight() + padding * 2;
+            const position = app.element.position(); // JQuery position function.
             const left = window.screenX + position.left - padding;
             const top = window.screenY + position.top - padding;
             windowFeatures = `toolbar=0, location=0, menubar=0, titlebar=0, scrollbars=1, innerWidth=${innerWidth}, innerHeight=${innerHeight}, left=${left}, top=${top}`;
         }
+        return windowFeatures;
+    }
 
-        const dest = window.origin + "/__popout" // Deliberate 404
-        const popout = window.open(dest, "_blank", windowFeatures);
+    createWindow(features) {
+        const dest = window.origin + "/modules/popout/popout.html";
+        this.log("dest", dest);
+        const popout = window.open(dest, "_blank", features);
         popout.location.hash = "popout";
         popout._rootWindow = window;
-
         this.log("Window opened", dest, popout);
+        return popout;
+    }
 
-        if (!popout) {
-            appNode.style.display = "revert"; // If we failed to open the window, show the app again.
-            appNode._minimized = false;
-            ui.notifications.warn(`Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`);
+    onPopoutClicked(domID, app) {
+        // Check if popout in Electron window
+        if (navigator.userAgent.toLowerCase().indexOf(" electron/") !== -1) {
+            ui.notifications.warn(
+                "Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser."
+            );
             return;
         }
 
+        const windowFeatures = this.windowFeatures(app);
+
+        // -------------------- Obtain application --------------------
+        const state = {
+            node: app.element[0],
+            position: duplicate(app.position),
+            minimized: app._minimized,
+            display: app.element[0].style.display,
+            css: app.element[0].style.cssText,
+            children: [],
+        };
+
+        // Hide the original node;
+        state.node.style.display = "none";
+
+        // --------------------------------------------------------
+
+        const popout = this.createWindow(windowFeatures);
+
+        if (!popout) {
+            this.log("Failed to open window", popout);
+            state.node.style.display = state.display;
+            state.node._minimized = false;
+            ui.notifications.warn(
+                `Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`
+            );
+            return;
+        }
+
+        // This is fiddly and probably not that robust to other modules.
+        // But does provide behavior closer to the vanilla fvtt iterations.
+        state.header = state.node.querySelector(".window-header");
+        if (state.header) {
+            state.header.remove();
+        }
+
+        state.handle = state.node.querySelector(".window-resizable-handle");
+        if (state.handle) {
+            state.handle.remove();
+        }
+
+        // We have to clone the header element and then remove the children
+        // into it to ensure that the drag behavior is ignored.
+        // however we have to manually move the actual controls over,
+        // so that their event handlers are preserved.
+        const shallowHeader = state.header.cloneNode(false);
+        shallowHeader.classList.remove("draggable");
+        for (const child of [...state.header.children]) {
+            if (child.id == domID) {
+                child.style.display = "none";
+            }
+            shallowHeader.appendChild(child);
+        }
+        // re-parent the new shallow header to the app node.
+        state.node.insertBefore(shallowHeader, state.node.children[0]);
+
         // -------------------- Write document --------------------
 
-        const doc = popout.document;
-        doc.open();
-        doc.write(doctype);
-        doc.write(html.outerHTML);
-        doc.close();
-        doc.title = app.title;
+        const serializer = new XMLSerializer();
+        const doctype = serializer.serializeToString(document.doctype);
+
+        const srcDoc = this.createDocument();
+        const targetDoc = popout.document;
+
+        targetDoc.open();
+        targetDoc.write(doctype);
+        targetDoc.write(srcDoc.outerHTML);
+        targetDoc.close();
+        targetDoc.title = app.title;
 
         // -------------------- Add unload handlers --------------------
 
@@ -237,20 +323,55 @@ class PopoutModule {
         });
 
         popout.addEventListener("unload", async (event) => {
-            this.log("Unload event", event, popout.location.href);
+            this.log("Unload event", event);
             const appId = app.appId;
             if (this.poppedOut.has(appId)) {
+                const poppedOut = this.poppedOut.get(appId);
                 this.log("Closing popout", app.title);
-                app.position = appPosition; // Set the original position.
-                app._minimized = appMinimized;
-                await app.close();
-                await popout.close();
+                app.position = poppedOut.position; // Set the original position.
+                app._minimized = poppedOut.minimized;
+                app.render = poppedOut.render;
+                app.minimize = poppedOut.minimize;
+                app.maximize = poppedOut.maximize;
+                app.close = poppedOut.close;
+
+                // Restore header bar to original state.
+                const node = poppedOut.node;
+                node.style.cssText = poppedOut.css;
+                if (poppedOut.header) {
+                    const header = node.querySelector(".window-header");
+                    for (const child of [...header.children]) {
+                        if (child.id == domID) {
+                            child.style.display = "";
+                        }
+                        poppedOut.header.appendChild(child);
+                    }
+                    node.insertBefore(poppedOut.header, node.children[0]);
+                    header.remove();
+                }
+
+                if (poppedOut.handle) {
+                    node.appendChild(poppedOut.handle);
+                }
+
+                window.document.body.append(window.document.adoptNode(node));
+
+                // We explicitly close any open dialog applications
+                // because any other behavior would not make sense.
+                // we can't pop them back in because moving them is
+                // an irreversible operation at present.
+                for (const child of poppedOut.children) {
+                    if (child) {
+                        child.close();
+                    }
+                }
+
+                // Force a re-render;
+                app.render(true);
                 this.poppedOut.delete(appId);
+                await popout.close();
             }
             event.returnValue = true;
-            // TODO(aposney: 2020-07-26): PopIn.
-            // Need to save the original location and position and reset that before closing.
-            // But probably not worth the effort.
         });
 
         // -------------------- Move element to window --------------------
@@ -258,49 +379,57 @@ class PopoutModule {
         // We mimic the main games behavior by forcing new windows to open in a new tab.
         popout.addEventListener("click", (event) => {
             const a = event.target.closest("a[href]");
-            if (!a || (a.href === "javascript:void(0)")) {
+            if (!a || a.href === "javascript:void(0)") {
                 return;
             }
             this.log("opening url", event, a);
             event.preventDefault();
-            // NOTE(aposney: 2020-07-26):
-            // This *MUST* be window and not the popped out window.
-            // If it is popout.open it causes a crash on Firefox...
-            // So we will disable it for the moment.
+            // NOTE(posnet: 2020-07-26):
+            // Why would we want to use ownerDocument.defaultView?
+            // This would mean that the new tab opened from a link will be opened
+            // in the popped out window. Which would be the expected behavior instead
+            // of the main window which is the current behavior.
+            // However accessing the a.ownerDocument.defaultView crashes firefox.
+            // Because of this, `const win` *MUST* be window and not the popped out window (i.e. ownerDocument.defaultView).
+            // The following code block can be used once if firefox is fixed.
+            //
             // const win = a.ownerDocument.defaultView;
-            const win = undefined;
-            if (win) {
-                const opened = win.open(a.href, "_blank");
+            // if (win) {
+            //     const opened = win.open(a.href, "_blank");
+            // } else {
+            //     const opened = window.open(a.href, "_blank");
+            // }
 
-            } else {
-                const opened = window.open(a.href, "_blank");
-            }
-            if (!win) {
-                ui.notifications.warn(`Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`);
+            const opened = window.open(a.href, "_blank");
+            if (!opened) {
+                ui.notifications.warn(
+                    `Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`
+                );
             }
         });
 
         // We wait longer than just the DOMContentLoaded
         // because of how the document is constructed manually.
         popout.addEventListener("load", async (event) => {
-            const wrapper = event.target.getElementById(appNode.id);
+            const wrapper = event.target.getElementById(state.node.id);
             const body = event.target.getElementsByTagName("body")[0];
-            const node = doc.adoptNode(appNode);
+            const node = targetDoc.adoptNode(state.node);
 
-            body.append(node);
+            body.style.overflow = "auto";
+            body.append(state.node);
 
-            const toRemove = [".window-header", ".window-resizable-handle"];
-
-            for (const selector of toRemove) {
-                const elem = node.querySelector(selector);
-                if (elem) {
-                    elem.remove();
-                }
-            }
-            appNode.style.cssText = "display: flex; top: 0; left: 0; width: 100%; height: 100%"; // Fullscreen
+            state.node.style.cssText = `
+                display: flex;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                margin: 0 !important;
+                border-radius: 0 !important;
+                cursor: auto !important;
+            `; // Fullscreen
             app.setPosition({ width: "100%", height: "100%", top: 0, left: 0 });
             app._minimized = null;
-
 
             // These event listeners don't get migrated because they are attached to a jQuery
             // selected body. This could be more of an issue in future as anyone doing a delegated
@@ -308,48 +437,66 @@ class PopoutModule {
             // The following regex will find examples of delegated event handlers in foundry.js
             // `on\(("|')[^'"]+("|'), *("|')`
             const jBody = $(body);
-            jBody.on("click", "a.entity-link", window.TextEditor._onClickEntityLink);
-            jBody.on("dragstart", "a.entity-link", window.TextEditor._onDragEntityLink);
-            jBody.on("click", "a.inline-roll", window.TextEditor._onClickInlineRoll);
+            jBody.on(
+                "click",
+                "a.entity-link",
+                window.TextEditor._onClickEntityLink
+            );
+            jBody.on(
+                "dragstart",
+                "a.entity-link",
+                window.TextEditor._onDragEntityLink
+            );
+            jBody.on(
+                "click",
+                "a.inline-roll",
+                window.TextEditor._onClickInlineRoll
+            );
 
             this.log("Final node", node, app);
-
         });
-
-        // -------------------- Add app to out popout --------------------
-        this.poppedOut.set(app.appId, popout);
-
-
 
         // -------------------- Install intercept methods ----------------
 
         const oldRender = app.render.bind(app);
-        app.render = ((force, options) => {
+        app.render = (force, options) => {
             popout.focus();
             oldRender(force, options);
-        });
+        };
 
+        const oldClose = app.close.bind(app);
+        app.close = async () => {
+            // await popout.close();
+            await window.focus();
+            await oldClose();
+        };
 
         const oldMinimize = app.minimize.bind(app);
-        app.minimize = (() => {
+        app.minimize = () => {
             this.log("Trying to focus main window."); // Doesn't appear to work due to popout blockers.
             popout._rootWindow.focus();
             if (popout._rootWindow.getAttention) {
                 popout._rootWindow.getAttention();
             }
             oldMinimize();
-        });
+        };
 
         const oldMaximize = app.maximize.bind(app);
-        app.maximize = (() => {
+        app.maximize = () => {
             popout.focus();
             this.log("Trying to focus popout.", app.appId);
             oldMaximize();
-        });
+        };
+
+        state.window = popout;
+        state.render = oldRender;
+        state.minimize = oldMinimize;
+        state.maximize = oldMaximize;
+        state.close = oldClose;
+        this.poppedOut.set(app.appId, state);
     }
 }
 
-
 Hooks.on("ready", async () => {
-    await (new PopoutModule()).init();
+    await new PopoutModule().init();
 });

--- a/popout.js
+++ b/popout.js
@@ -72,6 +72,12 @@ class PopoutModule {
     }
 
     async addPopout(app) {
+        if (this.poppedOut.has(app.appId)) {
+            this.log("Already popped out");
+            this.poppedOut.get(app.appId).window.focus();
+            return;
+        }
+
         let waitRender = Math.floor(this.MAX_TIMEOUT / this.TIMEOUT_INTERVAL);
         while (
             app._state !== Application.RENDER_STATES.RENDERED &&
@@ -81,12 +87,6 @@ class PopoutModule {
         }
         if (app._state !== Application.RENDER_STATES.RENDERED) {
             this.log("Timeout out waiting for app to render");
-            return;
-        }
-
-        if (this.poppedOut.has(app.appId)) {
-            this.log("Already popped out");
-            this.poppedOut.get(app.appId).window.focus();
             return;
         }
 

--- a/popout.js
+++ b/popout.js
@@ -1,104 +1,167 @@
-
-
 class PopoutModule {
-	static log(msg, ...args) {
-		if (game && game.settings.get("popout", "verboseLogs")) {
-			const color = "background: #6699ff; color: #000; font-size: larger;";
-			console.debug(`%c PopoutModule: ${msg}`, color, ...args);
-		}
-	}
+    constructor() {
+        this.poppedOut = new Map();
+        this.TIMEOUT_INTERVAL = 25 // ms
+        this.MAX_TIMEOUT = 250; // ms
+        // Random id to prevent collision with other modules;
+        this.ID = [...Array(24)].map(() => Math.floor(Math.random() * 16).toString(16)).join("");
+    }
 
-	static async init() {
-		game.settings.register("popout", "useWindows", {
-			name: "Pop sheets out into windows",
-			hint: "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
-			scope: "client",
-			config: true,
-			default: false,
-			type: Boolean
-		});
+    log(msg, ...args) {
+        if (game && game.settings.get("popout", "verboseLogs")) {
+            const color = "background: #6699ff; color: #000; font-size: larger;";
+            console.debug(`%c PopoutModule: ${msg}`, color, ...args);
+        }
+    }
 
-		game.settings.register("popout", "verboseLogs", {
-			name: "Enable more module logging.",
-			hint: "Enables more verbose module logging. This is useful for debugging the module. But otherwise should be left off.",
-			scope: "client",
-			config: true,
-			default: false,
-			type: Boolean
-		});
+    async init() {
+        game.settings.register("popout", "useWindows", {
+            name: "Pop sheets out into windows",
+            hint: "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
+            scope: "client",
+            config: true,
+            default: false,
+            type: Boolean
+        });
 
-		// Ideally there is a better way to enumerate hooks.
-		// or at least book the core application. But I guess that is an
-		// argument that this should be part of core, foundry.
-		const hookPoints = [
-			"renderFrameViewer",
-			"renderSettingsViewer",
-			"renderMacroConfig",
-			"renderModuleManagement",
-			"renderSceneConfig",
-			"renderRollTableConfig",
-			"renderJournalSheet", 
-			"renderItemSheet",
-			"renderCompendium",
-			"renderActorSheet",
-		]
-
-		for (const hook of hookPoints) {
-			Hooks.on(hook, this.addPopout.bind(this));
-		}
-
-		this.log("Attached popout hooks", hookPoints);
-
-		// HACK(aposney: 2020-07-12): we need to init tinymce to ensure it's plugins 
-		// are loaded into the frame. Otherwise our popouts will not be able to access
-		// the lazy loaded javascript mce plugins. 
-		const elem = $("<div style=\"display: none;\"><p id=\"mce_init\"> foo </p></div>")
-		$('body').append(elem)
-		const config = {target: elem[0], plugins: CONFIG.TinyMCE.plugins};
-		const editor = await tinyMCE.init(config);
-		editor[0].remove();
-	}
-
-	static addPopout(app, node, data) {
-		this.log("testing");
-		// We can ignore node and data since we aren't planning on re-rendering
-		// the app, so the original element attached to the app is enough.
-		try {
-			return this._addPopout(app);
-		} catch(err) {
-			this.log(err);
-			throw err;
-		}
-	}
-
-	static _addPopout(app) {
-		if (!app.popOut) {
-			return;
-		}
-		const ID = "d25c3971"; // Random ID to avoid collisions.
-		const domID = `popout_${this.ID}_${app.appId}`;
-		if (!document.getElementById(domID)) { // Don't create a second link on re-renders;
-			this.log("Attached", app);
-			const link = $(`<a id="${domID}"><i class="fas fa-external-link-alt"></i>PopOut!</a>`)
-			link.on('click', () => this.onPopoutClicked(app));
-			app.element.find('.window-title').after(link);
-		}
-	}
+        game.settings.register("popout", "verboseLogs", {
+            name: "Enable more module logging.",
+            hint: "Enables more verbose module logging. This is useful for debugging the module. But otherwise should be left off.",
+            scope: "client",
+            config: true,
+            default: false,
+            type: Boolean
+        });
 
 
-	static onPopoutClicked(app) {
-		// Check if popout in Electron window
-		if (navigator.userAgent.toLowerCase().indexOf(" electron/") !== -1) {
-			ui.notifications.warn("Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.");
-			return;
-		}
+        // We replace the games window registry with a proxy object so we can intercept
+        // every new application window creation event.
+        const handler = {
+            set: (obj, prop, value) => {
+                const result = Reflect.set(obj, prop, value);
+                this.log("Intercept ui-window create", value)
+                try {
+                    if (value && value.options && value.options.popOut) {
+                        this.addPopout(value);
+                    }
+                } catch (err) {
+                    // We must never fail here.
+                    this.log(err);
+                }
+                return result
+            }
+        };
+        ui.windows = new Proxy(ui.windows, handler);
+        this.log("Installed window interceptor", ui.windows);
 
-		// Store original position for later use.
-		const appPosition = {...app.position};
+        // HACK(aposney: 2020-07-12): we need to init tinymce to ensure it's plugins 
+        // are loaded into the frame. Otherwise our popouts will not be able to access
+        // the lazy loaded javascript mce plugins. 
+        const elem = $("<div style=\"display: none;\"><p id=\"mce_init\"> foo </p></div>")
+        $("body").append(elem)
+        const config = { target: elem[0], plugins: CONFIG.TinyMCE.plugins };
+        const editor = await tinyMCE.init(config);
+        editor[0].remove();
+    }
+
+    addPopout(app) {
+        this._addPopout(app, 0);
+    }
+
+
+    _addPopout(app, recurse) {
+        if (recurse > this.MAX_TIMEOUT) {
+            this.log("Timeout out waiting for app to render");
+            return;
+        }
+
+        if (!(app._state == Application.RENDER_STATES.RENDERED)) {
+            window.setTimeout(() => {
+                this._addPopout(app, recurse + this.TIMEOUT_INTERVAL);
+            }, this.TIMEOUT_INTERVAL);
+            return;
+        }
+
+        if (this.poppedOut.has(app.appId)) {
+            this.log("Already popped out");
+            this.poppedOut.get(app.appId).focus();
+            return;
+        }
+
+
+        if (app && app.options && app.options.classes.includes("dialog")) {
+            this.log("is dialog");
+            if (app.actor && app.actor.apps) {
+                const keys = Object.keys(app.actor.apps);
+                this.log("has an apps keys", keys);
+                if (keys.length == 1) {
+                    const parent = app.actor.apps[keys[0]]
+                    if (this.poppedOut.has(parent.appId)) {
+                        this.log("Intercepting dialog of popped out window.");
+                        this.moveDialog(app, parent);
+                        return;
+                    }
+                }
+            }
+        }
+
+        const domID = `popout_${this.ID}_${app.appId}`;
+        if (!document.getElementById(domID)) { // Don't create a second link on re-renders;
+            const link = $(`<a id="${domID}"><i class="fas fa-external-link-alt"></i>Popout</a>`)
+            link.on("click", () => this.onPopoutClicked(app));
+            const title = app.element.find(".window-title").after(link);
+            this.log("Attached", app);
+        }
+    }
+
+    moveDialog(app, parent) {
+        const parentWindow = this.poppedOut.get(parent.appId);
+        const dialogNode = app.element[0];
+
+        // Hide element
+        const setDisplay = dialogNode.style.display;
+        dialogNode.style.display = "None";
+
+        const newHeader = parentWindow.document.createElement("header")
+        newHeader.setAttribute("class", "window-header flexrow");
+        const headerElements = dialogNode.children[0].children;
+        for (const element of Array.from(headerElements)) {
+            newHeader.appendChild(parentWindow.document.adoptNode(element));
+        }
+
+        dialogNode.children[0].remove()
+
+        const node = parentWindow.document.adoptNode(dialogNode);
+        node.style.top = "50%";
+        node.style.left = "50%";
+        node.style.transform = "translate(-50%, -50%)"
+
+        node.insertBefore(newHeader, node.children[0]);
+
+        parent.element[0].parentNode.insertBefore(node, parent.element[0].nextSibling);
+        node.style.display = setDisplay;
+    }
+
+
+    onPopoutClicked(app) {
+        // Check if popout in Electron window
+        if (navigator.userAgent.toLowerCase().indexOf(" electron/") !== -1) {
+            ui.notifications.warn("Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.");
+            return;
+        }
+
+        // -------------------- Obtain application --------------------
+
+        // Store original position for later use.
+        const appPosition = { ...app.position };
+        const appMinimized = app._minimized;
+
 
         // Hide the original node;
-		const appNode = app.element[0];
-		appNode.style.display = "none";
+        const appNode = app._element[0];
+        appNode.style.display = "none";
+
+        // -------------------- Create Document --------------------
 
         // Create the new document.
         // Currently using raw js apis, since I need to ensure
@@ -108,94 +171,131 @@ class PopoutModule {
         // We do this before opening the window because technically writing
         // to the new window is race condition with the page load.
         // But since we are directing to a 404, it doesn't matter other than for UX purposes.
-		const html = document.createElement("html");
-		const serializer = new XMLSerializer();
-		const doctype = serializer.serializeToString(document.doctype);
-		const head = document.importNode(document.getElementsByTagName("head")[0], true);
-		const body = document.importNode(document.getElementsByTagName("body")[0], false);
+        const html = document.createElement("html");
+        const serializer = new XMLSerializer();
+        const doctype = serializer.serializeToString(document.doctype);
+        const head = document.importNode(document.getElementsByTagName("head")[0], true);
+        const body = document.importNode(document.getElementsByTagName("body")[0], false);
 
-		// Remove script tags from cloned head.
-		for (const child of [...head.children]) {
-			if (child.nodeName === "SCRIPT") {
-				child.remove();
-			}
-		}
+        // Remove script tags from cloned head.
+        for (const child of [...head.children]) {
+            if (child.nodeName === "SCRIPT") {
+                child.remove();
+            }
+        }
 
-		html.appendChild(head);
-		html.appendChild(body);
+        html.appendChild(head);
+        html.appendChild(body);
 
-		// Document created.
+        // -------------------- Create window --------------------
 
-		let windowFeatures = undefined;
-		if (game.settings.get("popout", "useWindows")) {
-			const padding = 30;
-            const innerWidth = app.element.innerWidth() + padding * 2;
-            const innerHeight = app.element.innerHeight() + padding * 2;
-            const position = app.element.position;
+        let windowFeatures = undefined;
+        if (game.settings.get("popout", "useWindows")) {
+            const padding = 30;
+            const innerWidth = app._element.innerWidth() + padding * 2;
+            const innerHeight = app._element.innerHeight() + padding * 2;
+            const position = app._element.position;
             const left = window.screenX + position.left - padding;
             const top = window.screenY + position.top - padding;
             windowFeatures = `toolbar=0, location=0, menubar=0, titlebar=0, scrollbars=1, innerWidth=${innerWidth}, innerHeight=${innerHeight}, left=${left}, top=${top}`;
         }
 
-        const dest = window.origin + '/__popout' // Deliberate 404
-		const popout = window.open(dest, '_blank', windowFeatures);
+        const dest = window.origin + "/__popout" // Deliberate 404
+        const popout = window.open(dest, "_blank", windowFeatures);
 
-		this.log("Window opened", dest, popout);
+        this.log("Window opened", dest, popout);
 
-		if (!popout) {
-			appNode.style.display = "revert"; // If we failed to open the window, show the app again.
-			appNode._minimized = false;
-			ui.notifications.warn(`Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`);
-			return;
-		}
+        if (!popout) {
+            appNode.style.display = "revert"; // If we failed to open the window, show the app again.
+            appNode._minimized = false;
+            ui.notifications.warn(`Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`);
+            return;
+        }
+
+        // -------------------- Write document --------------------
+
+        const doc = popout.document;
+        doc.open();
+        doc.write(doctype);
+        doc.write(html.outerHTML);
+        doc.close();
+        doc.title = app.title;
+
+        // -------------------- Add unload handlers --------------------
+
+        window.addEventListener("beforeunload", async () => {
+            await popout.close();
+        });
+
+        popout.addEventListener("beforeunload", async () => {
+            this.log("Clossing popout", app.title);
+            app.position = appPosition; // Set the original position.
+            app._minimized = appMinimized;
+            this.poppedOut.delete(app.appId);
+            await app.close();
+            await popout.close();
+            // TODO: PopIn.
+            // Need to save the original location and position and reset that before closing.
+            // But probably not worth the effort.
+        });
 
 
-		const doc = popout.document;
-		doc.open();
-		doc.write(doctype);
-		doc.write(html.outerHTML);
-		doc.close();
-		doc.title = app.title;
+        // -------------------- Move element to window --------------------
 
-		window.addEventListener("beforeunload", async () => {
-			await popout.close();
-		});
+        // We wait longer than just the DOMContentLoaded
+        // because of how the document is constructed manually.
+        popout.addEventListener("load", async (event) => {
+            const wrapper = event.target.getElementById(appNode.id);
+            const body = event.target.getElementsByTagName("body")[0];
+            const node = doc.adoptNode(appNode);
 
-		popout.addEventListener("beforeunload", async () => {
-			this.log("Clossing popout", app.title);
-			app.position = appPosition; // Set the original position.
-			await app.close();
-			await popout.close();
-			// TODO: PopIn.
-			// Need to save the original location and position and reset that before closing.
-			// But probably not worth the effort.
-		});
+            body.append(node);
 
-		// We wait longer than just the DOMContentLoaded
-		// because of how the document is constructed manually.
-		popout.addEventListener("load", async (event) => {
-			const wrapper = event.target.getElementById(appNode.id);
-			const body = event.target.getElementsByTagName("body")[0];
-			const node = doc.adoptNode(appNode);
+            const toRemove = [".window-header", ".window-resizable-handle"];
 
-			body.append(node);
+            for (const selector of toRemove) {
+                const elem = node.querySelector(selector);
+                if (elem) {
+                    elem.remove();
+                }
+            }
+            appNode.style.cssText = "display: flex; top: 0; left: 0; width: 100%; height: 100%"; // Fullscreen
+            app.setPosition({ width: "100%", height: "100%", top: 0, left: 0 });
+            app._minimized = null;
+            this.log("Final Node", node, app);
+        });
 
-			const toRemove = [".window-header", ".window-resizable-handle"];
+        // -------------------- Add app to out popout --------------------
+        this.poppedOut.set(app.appId, popout);
 
-			for (const selector of toRemove) {
-				const elem = node.querySelector(selector);
-				if (elem) {
-					elem.remove();
-				}
-			}
-			appNode.style.cssText = "display: flex; top: 0; left: 0; width: 100%; height: 100%"; // Fullscreen
-			app.setPosition({width: '100%', height: '100%', top: 0, left: 0});
-			this.log("Final Node", node, app);
-		});
-	}
+
+
+        // -------------------- Install intercept methods ----------------
+
+        const oldRender = app.render.bind(app);
+        app.render = ((force, options) => {
+            popout.focus();
+            oldRender(force, options);
+        });
+
+
+        const oldMinimize = app.minimize.bind(app);
+        app.minimize = (() => {
+            this.log("Trying to focus main window."); // Doesn't appear to work due to popout blockers.
+            window.focus();
+            oldMinimize();
+        });
+
+        const oldMaximize = app.maximize.bind(app);
+        app.maximize = (() => {
+            popout.focus();
+            this.log("Trying to focus popout.", app.appId);
+            oldMaximize();
+        });
+    }
 }
 
 
-Hooks.on('ready', async () => {
-	PopoutModule.init();
+Hooks.on("ready", async () => {
+    await (new PopoutModule()).init();
 });

--- a/popout.js
+++ b/popout.js
@@ -1,241 +1,192 @@
+
+
 class PopoutModule {
-	static onRenderJournalSheet(sheet, html, data) {
-		let element = html.find(".window-header .window-title")
-		PopoutModule.addPopout(element, sheet, `game.journal.get("${sheet.entity.id}").sheet`);
+	constructor() {
+		this.ID = "d25c3971"; // Random ID to avoid collisions.
 	}
-	static onRenderActorSheet(sheet, html, data) {
-		let element = html.find(".window-header .window-title")
-		PopoutModule.addPopout(element, sheet, `game.actors.get("${sheet.entity.id}").sheet`);
+
+	static log(msg, ...args) {
+		if (game && game.settings.get("popout", "verboseLogs")) {
+			const color = "background: #6699ff; color: #000; font-size: larger;";
+			console.debug(`%c PopoutModule: ${msg}`, color, ...args);
+		}
 	}
-	static onRenderSidebarTab(sidebar, html, data) {
-        if (!sidebar.options.popOut) return;
-		let element = html.find(".window-header .window-title")
-		PopoutModule.addPopout(element, sidebar, `ui["${sidebar.tabName}"]`, "renderSidebar", 0);
+
+	static init() {
+		game.settings.register("popout", "useWindows", {
+			name: "Pop sheets out into windows",
+			hint: "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
+			scope: "client",
+			config: true,
+			default: false,
+			type: Boolean
+		});
+
+		game.settings.register("popout", "verboseLogs", {
+			name: "Enable more module logging.",
+			hint: "Enables more verbose module logging. This is useful for debugging the module. But otherwise should be left off.",
+			scope: "client",
+			config: true,
+			default: false,
+			type: Boolean
+		});
+
+		// Ideally there is a better way to enumerate hooks.
+		// or at least book the core application. But I guess that is an
+		// argument that this should be part of core, foundry.
+		const hookPoints = [
+			"renderFrameViewer",
+			"renderSettingsViewer",
+			"renderMacroConfig",
+			"renderModuleManagement",
+			"renderSceneConfig",
+			"renderRollTableConfig",
+			"renderJournalSheet", 
+			"renderItemSheet",
+			"renderCompendium",
+			"renderActorSheet",
+		]
+
+		for (const hook of hookPoints) {
+			Hooks.on(hook, this.addPopout.bind(this));
+		}
+
+		this.log("Attached popout hooks", hookPoints);
 	}
-	static addPopout(element, sheet, sheetGetter, renderer="renderSheet", timeout=2500) {
-		// Can't find it?
-		if (element.length != 1) {
+
+	static addPopout(app, node, data) {
+		this.log("testing");
+		// We can ignore node and data since we aren't planning on re-rendering
+		// the app, so the original element attached to the app is enough.
+		try {
+			return this._addPopout(app);
+		} catch(err) {
+			this.log(err);
+			throw err;
+		}
+	}
+
+	static _addPopout(app) {
+		if (!app.popOut) {
 			return;
 		}
-		let popout = $('<a class="popout" style><i class="fas fa-external-link-alt"></i>PopOut!</a>')
-		popout.on('click', (event) => PopoutModule.onPopoutClicked(event, sheet, sheetGetter, renderer, timeout))
-		element.after(popout)
 
+		const id = `popout_${this.ID}_${app.appId}`;
+		if (!document.getElementById(id)) { // Don't create a second link on re-renders;
+			this.log("Attached", app);
+			const link = $(`<a id="${id}"><i class="fas fa-external-link-alt"></i>PopOut!</a>`)
+			link.on('click', () => this.onPopoutClicked(app));
+			app.element.find('.window-title').after(link);
+		}
 	}
-	static onPopoutClicked(event, sheet, sheetGetter, renderer, timeout) {
-        const padding = 30;
+
+
+	static onPopoutClicked(app) {
 		// Check if popout in Electron window
 		if (navigator.userAgent.toLowerCase().indexOf(" electron/") !== -1) {
-			return ui.notifications.warn("Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.");
+			ui.notifications.warn("Popout! cannot work within the standalone FVTT Application. Please open your game from a regular browser.");
+			return;
 		}
 
-		let div = $(event.target).closest("div")
-		let window_title = div.find(".window-title").text().trim()
+        // Hide the original node;
+		const appNode = app.element[0];
+		appNode.style.display = "none";
 
-		// Create a new html document
-		let html = $("<html>")
-		let head = $("<head>")
-		let body = $("<body>")
+        // Create the new document.
+        // Currently using raw js apis, since I need to ensure
+        // jquery isn't doing something sneaky underneath.
+        // In particular it makes some assumptions about there
+        // being a single document.
+        // We do this before opening the window because technically writing
+        // to the new window is race condition with the page load.
+        // But since we are directing to a 404, it doesn't matter other than for UX purposes.
+		const html = document.createElement("html");
+		const serializer = new XMLSerializer();
+		const doctype = serializer.serializeToString(document.doctype);
+		const head = document.importNode(document.getElementsByTagName("head")[0], true);
+		const body = document.importNode(document.getElementsByTagName("body")[0], false);
 
-		// Copy classes from html/head/body tags and add title
-		html.attr("class", $("html").attr("class"))
-		head.attr("class", $("head").attr("class"))
-		body.attr("class", $("body").attr("class"))
-		head.append($("<title>" + window_title + "</title>"))
-		html.append(head)
-		html.append(body)
-
-		// Copy the scripts and css so the sheet appears correctly
-		for (let link of $("head link")) {
-			let new_link = $(link).clone()
-			// Replace the href with the full URL
-			if (new_link.href != "")
-				new_link.attr("href", link.href)
-			head.append(new_link)
+		// Remove script tags from cloned head.
+		for (const child of [...head.children]) {
+			if (child.nodeName === "SCRIPT") {
+				child.remove();
+			}
 		}
-		for (let script of $("head script,body script")) {
-			let new_script = $(script).clone()
-			// Replace the src with the full URL
-			if (script.src != "")
-				new_script.attr("src", script.src)
-			head.append(new_script)
-		}
-		// Create a callable canvas with a universal proxy so canvas.notes.placeables.filter() doesn't crash on journal updates.
-		head.append($(`<script>
-					handlers = {
-						get: (obj, name) => {
-							if (name === 'length') return 0;
-							if (name === 'scene') return game.scenes.entities.find(s => s.active) || canvas;
-							if (name === 'dimensions') return {
-								width: 1,
-								sceneWidth: 1,
-								height: 1,
-								sceneHeight: 1,
-								size: canvas.scene.data.grid,
-								distance: canvas.scene.data.gridDistance,
-								shiftX: canvas.scene.data.shiftX,
-								shiftY: canvas.scene.data.shiftY,
-								ratio: 1,
-								paddingX: 0,
-								paddingY: 0,
-                            };
-                            if (name === 'ready') return false;
-							return canvas;
-						},
-						set: () => true
-					};
-                    canvas = new Proxy(() => canvas, handlers);
-                    Playlist.prototype.playSound = () => {}
-                    WebRTC.prototype.connect = () => {}
-				</script>`))
-		// Avoid having the UI initialized which renders the chatlog and all sorts
-		// of other things behind the sheet
-		body.append($(`<script>
-		      Game.prototype.initializeUI = function() {
-							ui.nav = new SceneNavigation();
-							ui.controls = new SceneControls();
-							ui.notifications = new Notifications().render();
-							ui.sidebar = new Sidebar();
-							// Back to initializeUI 
-							ui.players = new PlayerList();
-							ui.hotbar = new Hotbar();
-							ui.webrtc = new CameraViews(this.webrtc);
-							ui.pause = new Pause();
-							ui.menu = new MainMenu();
 
-							// sidebar elements only get created on the render
-							// but we don't want to render them
-							ui.chat = new ChatLog({tabName: "chat"})
-							ui.combat = new CombatTracker({tabName: "combat"})
-							ui.scenes = new SceneDirectory({tabName: "scenes"})
-							ui.actors = new ActorDirectory({tabName: "actors"})
-							ui.items = new ItemDirectory({tabName: "items"})
-							ui.journal = new JournalDirectory({tabName: "journal"})
-							ui.tables = new RollTableDirectory({tabName: "tables"})
-							ui.playlists = new PlaylistDirectory({tabName: "playlists"})
-							ui.compendium = new CompendiumDirectory({tabName: "compendium"})
-							ui.settings = new Settings({tabName: "settings"})
-					}
-							
-				KeyboardManager.prototype._onEscape = function(event, up, modifiers) {
-					if ( up || modifiers.hasFocus ) return;
+		html.appendChild(head);
+		html.appendChild(body);
 
-					// Case 1 - dismiss an open context menu
-					if ( ui.context && ui.context.menu.length ) ui.context.close();
+		// Document created.
 
-					// Case 2 - close open UI windows
-					else if ( Object.keys(ui.windows).length ) {
-						Object.values(ui.windows).filter(w => w.id !== ${sheetGetter}.id).forEach(app => app.close());
-					}
-
-					// Flag the keydown workflow as handled
-					this._handled.add(event.keyCode);
-				}
-				// Add delay before rendering in case some things aren't done initializing, like sheet templates
-				// which get loaded asynchronously.
-				Hooks.on('ready', () => setTimeout(() => PopoutModule.${renderer}(${sheetGetter}), ${timeout}));
-		  	window.dispatchEvent(new Event('load'))
-		  </script>`))
-		// Open new window and write the new html document into it
-		// We need to open it to the same url because some images use relative paths
 		let windowFeatures = undefined;
 		if (game.settings.get("popout", "useWindows")) {
-            const innerWidth = sheet.element.innerWidth() + padding * 2;
-            const innerHeight = sheet.element.innerHeight() + padding * 2;
-            const position = sheet.element.position();
+			const padding = 30;
+            const innerWidth = app.element.innerWidth() + padding * 2;
+            const innerHeight = app.element.innerHeight() + padding * 2;
+            const position = app.element.position;
             const left = window.screenX + position.left - padding;
             const top = window.screenY + position.top - padding;
             windowFeatures = `toolbar=0, location=0, menubar=0, titlebar=0, scrollbars=1, innerWidth=${innerWidth}, innerHeight=${innerHeight}, left=${left}, top=${top}`;
         }
-		let win = window.open(window.location.toString(), '_blank', windowFeatures)
-		//console.log(win)
-		// Need to specify DOCTYPE so the browser is in standards mode (fixes TinyMCE and CSS)
-		win.document.write("<!DOCTYPE html>" +  html[0].outerHTML)
-		// After doing a write, we need to do a document.close() so it finishes
-		// loading and emits the load event.
-        win.document.close()
-        if (game.settings.get('popout', 'closeSheet'))
-            sheet.close();
-	}
 
-	static renderSheet(sheet) {
-        const padding = 30;
-		sheet.options.minimizable = false;
-		sheet.options.resizable = false;
-		sheet.options.id = "popout-" + sheet.id;
-		sheet.options.closeOnSubmit = false;
-		// Without setting the id, re-rendering the sheet unmaximizes it and custom classes for CSS (shadowrun) don't get set.
-		Object.defineProperty(sheet, 'id', { value: sheet.options.id, writable: true, configurable: true });
-		// Replace the render function so if it gets re-rendered (such as switching journal view mode), we can
-		// re-maximize it.
-		sheet._original_popout_render = sheet._render
-		// Prevent the sheet from getting minimized
-		sheet.minimize = () => { }
-		sheet._render = async function (force, options) {
-			await this._original_popout_render(true, options);
-			// Maximum it
-			sheet.element.css({
-                width: `calc(100% - ${padding * 2}px)`,
-                height: `calc(100% - ${padding * 2}px)`,
-                top: `${padding}px`,
-                left: `${padding}px`
-            })
-			// Remove the close and popout buttons
-			sheet.element.find("header .close, header .popout").remove()
-			let minWidth = parseInt(sheet.element.css('min-width'), 10);
-			let minHeight = parseInt(sheet.element.css('min-height'), 10);
-			// Make sure overflow scrollbars appear only when necessary
-			window.onresize = () => {
-				if (minWidth || minHeight) {
-					const bounds = document.body.getBoundingClientRect();
-					if (minWidth) 
-						document.body.style['overflow-x'] = bounds.width < minWidth ? 'overlay' : 'hidden';
-					if (minHeight) 
-						document.body.style['overflow-y'] = bounds.height < minHeight ? 'overlay' : 'hidden';
+        const dest = window.origin + '/__popout' // Deliberate 404
+		const popout = window.open(dest, '_blank', windowFeatures);
+
+		this.log("Window opened", dest, popout);
+
+		if (!popout) {
+			appNode.style.display = "revert"; // If we failed to open the window, show the app again.
+			appNode._minimized = false;
+			ui.notifications.warn(`Unable to open PopOut! window. Please check your site settings/permissions. Click the <i class="fas fa-info-circle"></i> to the left of the website URL.`);
+			return;
+		}
+
+
+		const doc = popout.document;
+		doc.open();
+		doc.write(doctype);
+		doc.write(html.outerHTML);
+		doc.close();
+		doc.title = app.title;
+
+		window.addEventListener("beforeunload", async () => {
+			await popout.close();
+		});
+
+		popout.addEventListener("beforeunload", async () => {
+			this.log("Clossing popout", app.title);
+			await app.close();
+			await popout.close();
+			// TODO: PopIn.
+			// Need to save the original location and position and reset that before closing.
+			// But probably not worth the effort.
+		});
+
+		// We wait longer than just the DOMContentLoaded
+		// because of how the document is constructed manually.
+		popout.addEventListener("load", async (event) => {
+			const wrapper = event.target.getElementById(appNode.id);
+			const body = event.target.getElementsByTagName("body")[0];
+			const node = doc.adoptNode(appNode);
+
+			body.append(node);
+
+			const toRemove = [".window-header", ".window-resizable-handle"];
+
+			for (const selector of toRemove) {
+				const elem = node.querySelector(selector);
+				if (elem) {
+					elem.remove();
 				}
 			}
-			window.onresize();
-			Hooks.callAll("popout:renderSheet", sheet);
-		}
-		sheet.render(true);
+			appNode.style.cssText = "display: flex; top: 0; left: 0; width: 100%; height: 100%"; // Fullscreen
+			app.setPosition({width: '100%', height: '100%', top: 0, left: 0});
+			this.log("Final Node", node, app);
+		});
 	}
-	static async renderSidebar(sidebar) {
-        const padding = 10;
-        const popout = sidebar.createPopout();
-        ui[sidebar.tabName] = popout;
-		popout.options.width = `100%`;
-		popout.options.height = `100%`;
-        await popout._render(true);
-        // Maximum it
-        popout.element.css({
-            width: `calc(100% - ${padding * 2}px)`,
-            height: `calc(100% - ${padding * 2}px)`,
-            top: `${padding}px`,
-            left: `${padding}px`
-        })
-        // Remove the close and popout buttons
-        popout.element.find("header .close, header .popout").remove()
-    }
 }
 
+
 Hooks.on('ready', () => {
-	game.settings.register("popout", "useWindows", {
-		name: "Pop sheets out into windows",
-		hint: "Force the popped out sheet to be a window with minimal decorations. Otherwise uses your browser's default (a new tab most likely)",
-		scope: "client",
-		config: true,
-		default: false,
-		type: Boolean
-	});
-	game.settings.register("popout", "closeSheet", {
-		name: "Close sheet on Popout",
-		hint: "Closes the sheet in FVTT when it gets popped out",
-		scope: "client",
-		config: true,
-		default: true,
-		type: Boolean
-	});
-	Hooks.on('renderJournalSheet', PopoutModule.onRenderJournalSheet);
-	Hooks.on('renderActorSheet', PopoutModule.onRenderActorSheet);
-	Hooks.on('renderSidebarTab', PopoutModule.onRenderSidebarTab)
+	PopoutModule.init();
 });


### PR DESCRIPTION
This popout method uses dom node migration instead of recreating the entire fvtt instance. This ensures that the event handlers and hooks interact correctly with the popout. It is still not as robust as an implementation in core. However it provides marginally more complete functionality than the current method, with a few caveats. The major one being it doesn't support tab popouts that don't already support being a window, i.e. chat. It also makes some assumptions about fvtt internal state and accesses private variables, so may break with future updates, even though it tries to keep this to a minimum.